### PR TITLE
Make sidecar cookie compatible w/ express-session

### DIFF
--- a/com/sidecar.cfc
+++ b/com/sidecar.cfc
@@ -185,9 +185,10 @@ component {
 			touch(genSessionID(), true);
 			doLog("NoExistingSession");
 		} else {
-			var val = unsign(newSecret, cookie[variables.cookieName]);
+			var cookieVal = readCookie();
+			var val = unsign(newSecret, cookieVal);
 			if (val == false) {
-				val = unsign(oldSecret, cookie[variables.cookieName]);
+				val = unsign(oldSecret, cookieVal);
 				if (val == false) {
 					//cookie exists, but is invalid session
 					//delete existing cookie
@@ -257,8 +258,12 @@ component {
 		return this;
 	}
 
+	private function readCookie(){
+		return reReplace(cookie[variables.cookieName], '^s\:', '');
+	}
+
 	private function writeCookie (expires, secret) {
-		cookie[variables.cookieName] = {value: sign(secret, request[variables.cookieName])
+		cookie[variables.cookieName] = {value: 's:' & sign(secret, request[variables.cookieName])
 				, path: cookieOptions.path
 				, httpOnly: cookieOptions.httpOnly
 				, secure: cookieOptions.secure
@@ -435,7 +440,7 @@ component {
 			input = join(input);
 		}
 
-		return input & "." & toBase64(binaryDecode(hmac(replace(input, "\n", chr(10), "all"), secret, "HmacSHA1"), "hex"));
+		return input & "." &  rereplace(toBase64(binaryDecode(hmac(replace(input, "\n", chr(10), "all"), secret, "HmacSHA256"), "hex"), "utf-8"), "\=+$", "");
 	}
 
 	private string function unsign (required string secret, required string val) {

--- a/tests/basic/cookieOptionsTest.cfc
+++ b/tests/basic/cookieOptionsTest.cfc
@@ -27,7 +27,7 @@ component extends="testbox.system.BaseSpec" {
 
 				expect(request).toHaveKey("someUniqueCookieName");
 				expect(request.someUniqueCookieName).notToBeEmpty();
-				expect(listFirst(cookie.someUniqueCookieName, ".")).toBe(request.someUniqueCookieName);
+				expect(reReplace(listFirst(cookie.someUniqueCookieName, "."), "^s\:", "")).toBe(request.someUniqueCookieName);
 				expect(request.someUniqueCookieName).toBe(application.sidecar.getSessionID());
 
 			});
@@ -38,6 +38,21 @@ component extends="testbox.system.BaseSpec" {
 			});
 		});
 
+		describe("signatures", function () {
+
+			it("should produce the same signature as node's cookie-signature module for compat", function() {
+
+				makePublic(application.sidecar, "sign", "publicSign");
+
+				//these inputs and outputs are values that were run through node-cookie-signature to obtain reference values
+				expect( application.sidecar.publicSign( "b42527", "a" ) ).toBe("a.GgASGmQ1e95bMuS1woXgCTrIq3cVwALSUhIc0pzyz/Y");
+				expect( application.sidecar.publicSign( "b42527", "adam" ) ).toBe("adam.Jrqs4C8bgqgd5J0MBNPPGE6YFNSD9uhYFz6cY74kz1g");
+				expect( application.sidecar.publicSign( "b42527", "this is a test" ) ).toBe("this is a test.Az8Q+c+kASA7GroDGLUlzfvgMHHusWkyDgJnK1GTNIY");
+				expect( application.sidecar.publicSign( "b42527", "ryan guill is the man" ) ).toBe("ryan guill is the man.AXdjwH9BGe6qUYkN/YZTiLn6EPm3r/F+KqHPdpuBCgY");
+
+			});
+
+		});
 
 	}
 

--- a/tests/basic/existingSessionTest.cfc
+++ b/tests/basic/existingSessionTest.cfc
@@ -62,7 +62,7 @@ component extends="testbox.system.BaseSpec" {
 			});
 
 			it("should have the same sessionID as in the cookie", function() {
-				expect(application.sidecar.getSessionID()).toBe(listFirst(cookie.sidecar_sid, "."));
+				expect(application.sidecar.getSessionID()).toBe(reReplace(listFirst(cookie.sidecar_sid, "."), "^s\:", ""));
 			});
 
 			it("should allow you to retrieve items stored as a collection individually", function() {

--- a/tests/basic/malformedCookieTest.cfc
+++ b/tests/basic/malformedCookieTest.cfc
@@ -26,7 +26,7 @@ component extends="testbox.system.BaseSpec" {
 
 				expect(request).toHaveKey("sidecar_sid");
 				expect(request.sidecar_sid).notToBeEmpty();
-				expect(listFirst(cookie.sidecar_sid, ".")).toBe(request.sidecar_sid);
+				expect(reReplace(listFirst(cookie.sidecar_sid, "."), "^s\:", "")).toBe(request.sidecar_sid);
 				expect(request.sidecar_sid).toBe(application.sidecar.getSessionID());
 
 			});

--- a/tests/basic/newSessionTest.cfc
+++ b/tests/basic/newSessionTest.cfc
@@ -51,7 +51,7 @@ component extends="testbox.system.BaseSpec" {
 			});
 
 			it("should have the same sessionID as in the cookie", function() {
-				expect(application.sidecar.getSessionID()).toBe(listFirst(cookie.sidecar_sid, "."));
+				expect(application.sidecar.getSessionID()).toBe(reReplace(listFirst(cookie.sidecar_sid, "."), "^s\:", ""));
 			});
 
 			it("should allow you to store a collection at once", function() {

--- a/tests/index.cfm
+++ b/tests/index.cfm
@@ -2,7 +2,7 @@
 The idea here is that the first request will not have any cookies, so call the tests that assume that,
 any cookies returned will be passed to the subsequent requests.
 --->
-
+<cfsetting requesttimeout="300" />
 <cfparam name="url.format" default="html" />
 
 


### PR DESCRIPTION
Given the same prefix & secret, a cookie written with sidecar will be readable by express-session, and vice-versa. This is paving the way for full compatibility with express-session, coming in a subsequent pull request.

This has no effect on other sidecar functionality, other than that it would break backwards compatibility for existing sessions, so you may want to bump the major version. For that reason you may want to wait until my other PR's are submitted to merge any of them so that you only have to bump the major version once.