### PR TITLE
Add an express-session compatible store adapter

### DIFF
--- a/com/express_redis_session_store.cfc
+++ b/com/express_redis_session_store.cfc
@@ -1,0 +1,225 @@
+component {
+
+	property any redis;
+	property string prefix;
+	property any redlock;
+
+	function init (required any redis, string prefix = "redis-session-store_") {
+		variables.redis = extendCFRedis(arguments.redis);
+		variables.prefix = arguments.prefix;
+		variables.request_key = "$_express_redis_session_data_$";
+
+		variables.redlock = new redlock([redis], {
+				retryCount: 2,
+				retryDelay: 150
+			});
+
+		return this;
+	}
+
+	private numeric function unixtimemillis () {
+		return createObject("java", "java.lang.System").currentTimeMillis();
+	}
+
+	private numeric function unixtime () {
+		return int(unixTimeMillis() / 1000);
+	}
+
+	private function getLockName (required string sessionID) {
+		return prefix & sessionID & "_lock";
+	}
+
+	function destroy (required string sessionID) {
+		var result = false;
+		redlock.lock(getLockName(sessionID), 200, function(err, lock) {
+			if (len(err)) throw(err);
+			result = redis.del(prefix & sessionID);
+			redis.zrem_fixed(prefix & "_session_expires", sessionID);
+			structDelete( request, variables.request_key );
+			lock.unlock();
+		});
+		return result;
+	}
+
+	//this function is used to make sure we only read from redis once per request
+	private function ensureCachedInRequest(required string sessionID){
+		if ( !structKeyExists(request, variables.request_key) ){
+			request[variables.request_key] = getEntireSession(sessionID);
+		}
+	}
+
+	function get (required string sessionID, required string key, any defaultValue) {
+		ensureCachedInRequest(sessionID);
+		if ( structKeyExists( request[variables.request_key], key ) ){
+			return request[variables.request_key][key];
+		}
+		if (!isNull(defaultValue)) {
+			return defaultValue;
+		}
+		return JavaCast("null", "");
+	}
+
+	function has (required string sessionID, required string key) {
+		ensureCachedInRequest(sessionID);
+		return structKeyExists( request[variables.request_key], key );
+	}
+
+	function clear (required string sessionID, required string key) {
+		//clear it from the request cache
+		ensureCachedInRequest(sessionID);
+		structDelete( request[variables.request_key], key );
+		//write session to redis
+		return setEntireSession(sessionID);
+	}
+
+	function getEntireSession (required string sessionID) {
+		var result = false;
+		redlock.lock(getLockName(sessionID), 200, function(err, lock) {
+			if (len(err)) throw(err);
+			var data = redis.get(prefix & sessionID);
+			if ( data == "" ){
+				result = { 'cookie': getSessionCookie() };
+			}else{
+				result = deserializeJson( data );
+			}
+			lock.unlock();
+		});
+		return result;
+	}
+
+	private function setEntireSession (required string sessionID) {
+		var result = false;
+		redlock.lock(getLockName(sessionID), 200, function(err, lock) {
+			if (len(err)) throw(err);
+			result = redis.set(prefix & sessionID, serializeJson( request[variables.request_key] ));
+			lock.unlock();
+		});
+		return result;
+	}
+
+	private function getSessionCookie () {
+		//todo: where should cookie contents come from? what about SECURE option?
+		return {
+			"originalMaxAge": javaCast("null", 0)
+			,"expires": javaCast("null", 0)
+			,"httpOnly": true
+			,"path": "/"
+		};
+	}
+
+	function set (required string sessionID, required string key, required string value) {
+		ensureCachedInRequest(sessionID);
+		request[variables.request_key][key] = value;
+		//write to redis
+		return setEntireSession(sessionID);
+	}
+
+	// this function will set each key in the collection separately, but in the same action
+	// use set() if you want to set the struct itself into one key
+	function setCollection (required string sessionID, required struct collection) {
+		ensureCachedInRequest(sessionID);
+
+		for (var key in collection) {
+			request[variables.request_key][key] = collection[key];
+		}
+
+		return setEntireSession(sessionID);
+	}
+
+	function touch (required any sessionID, required numeric expires) {
+		var result = false;
+		redlock.lock(getLockName(sessionID), 200, function(err, lock) {
+			if (len(err)) throw(err);
+			//result = redis.expire(prefix & sessionID, expires);
+			set(sessionID, "_session_expires", expires);
+			redis.zadd(prefix & "_session_expires", expires, sessionID);
+			lock.unlock();
+		});
+		return result;
+	}
+
+	function all () {
+		return redis.zrangeByScore(prefix & "_session_expires", "-inf", "+inf");
+	}
+
+	function expired (numeric expiredBefore = unixTime()) {
+		return redis.zrangeByScore(prefix & "_session_expires", "0", expiredBefore);
+	}
+
+	function length () {
+		var keys = redis.hKeys(prefix & "_session_expires");
+		return arrayLen(keys);
+	}
+
+	//cleanup routine that will delete everything from redis related to this session store, only necessary for testing!
+	function _wipe_all () {
+		var keys = redis.keys(prefix & "*");
+
+		for (var key in keys) {
+			redis.del(key);
+		}
+
+		return arrayLen(keys);
+	}
+
+	private function __zrem_fixed (key, member) {
+
+		if (!isArray(member)) {
+			member = [member];
+		}
+
+		var conn = getResource();
+		var result = conn.zrem(JavaCast("string", key), JavaCast("string[]", member));
+
+		returnResource(conn);
+
+		if (isNull(result)) {
+			result = 0;
+		}
+
+		return result;
+	}
+
+	private function __hgetReturnsUndefined (string key, string field) {
+		var conn = getResource();
+		var result = conn.hget(JavaCast("string", key), JavaCast("string", field));
+
+		returnResource(conn);
+
+		if (!isNull(result)) {
+			return result;
+		}
+
+		return JavaCast("null", "");
+	}
+
+	private function __inject (required string name, required any f, required boolean isPublic) {
+		if (isPublic) {
+			this[name] = f;
+			variables[name] = f;
+		} else {
+			variables[name] = f;
+		}
+	}
+
+	private function __cleanup () {
+		structDelete(variables, "__inject");
+		structDelete(this, "__inject");
+		structDelete(variables, "__cleanup");
+		structDelete(this, "__cleanup");
+	}
+
+	private function extendCFRedis (required target) {
+		//write the injector first
+		target["__inject"] = variables["__inject"];
+		target["__cleanup"] = variables["__cleanup"];
+
+		target.__inject("zrem_fixed", variables["__zrem_fixed"], true);
+		target.__inject("hgetReturnsUndefined", variables["__hgetReturnsUndefined"], true);
+
+		target.__cleanup();
+
+		return target;
+	}
+
+}

--- a/com/express_redis_session_store.cfc
+++ b/com/express_redis_session_store.cfc
@@ -114,7 +114,7 @@ component {
 		};
 	}
 
-	function set (required string sessionID, required string key, required string value) {
+	function set (required string sessionID, required string key, required value) {
 		ensureCachedInRequest(sessionID);
 		request[variables.request_key][key] = value;
 		//write to redis

--- a/com/sidecar.cfc
+++ b/com/sidecar.cfc
@@ -109,6 +109,9 @@ component {
 
 	function setDefaultSessionTimeout (required numeric timeoutSeconds) {
 		variables.defaultTimeoutSeconds = arguments.timeoutSeconds;
+		if ( structKeyExists(store, "setTTL")){
+			variables.store.setTTL( variables.defaultTimeoutSeconds );
+		}
 		return this;
 	}
 
@@ -120,6 +123,9 @@ component {
 
 	function setSessionStorage (required any sessionStorage) {
 		variables.store = arguments.sessionStorage;
+		if ( structKeyExists(store, "setTTL")){
+			variables.store.setTTL( variables.defaultTimeoutSeconds );
+		}
 		return this;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -12,14 +12,35 @@ This project depends on the following projects:
 - [Apache Commons Pool](https://commons.apache.org/proper/commons-pool/download_pool.cgi)
 
 
-##Support
+## Support
 Adobe ColdFusion 10+, Lucee 4.5+
 
 
-##Todo:
+## Todo:
 
 - [ ] `setCookieOptions()` testing, especially setting a custom cookie name
 - [ ] `_getEntireRequestCache()` testing
+
+## Configuring your application and using Sidecar
+
+Coming soon
+
+## Express-session compatibility
+
+While Sidecar was heavily inspired by [express-session](https://github.com/expressjs/session), it was not originally written as a direct port and is not compatible using the default settings. In order to be able to read and write your CFML+Sidecar session data, on Redis, from a Node.js application using express-session, you need to use the included **express_redis_session_store.cfc** store adapter instead of the usual **redis_session_store.cfc**.
+
+There is only one other change necessary from normal Sidecar usage: Your Sidecar (de)serializer functions need to be no-operation functions to prevent double serialization:
+
+	sidecar.setSerializerFunction( function(d){ return d; } );
+	sidecar.setDeserializerFunction( function(d){ return d; } );
+
+#### Buyer beware!
+
+This express-session compatible store adapter will store your data in the same way that express-session does. From CFML platforms, this approach is slightly less efficient than the standard approach with Sidecar. The standard adapter will use a Redis hash for each session, with keys for each session variable; and the express-session approach is to use a Redis string key containing the session data as an object (CFML struct) stored serialized to JSON.
+
+The express-session adapter will only read the session data from redis once per request, the first time it is requested, and caches it in the request scope. All writes update both Redis and the request scope cache. If you need to set multiple keys you can use the `sidecar.setCollection()` method to make this more efficient: 1 Redis write per collection, rather than per key.
+
+While the express-session store adapter is slightly less efficient than standard Sidecar usage, this can be an acceptable trade-off if you need session data to be portable between Node.js and CFML.
 
 ## How to run the tests
 

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,8 @@ The express-session compatible store adapter will store your data in the same wa
 
 The express-session adapter will only read the session data from redis once per request, the first time it is requested, and caches it in the request scope. All writes update both Redis and the request scope cache. If you need to set multiple keys you can use `sidecar.setCollection()` to make this more efficient: 1 Redis write per collection, rather than per key.
 
+This also means that unlike CFML sessions, data set during a request is not shared with other requests until the end of the request, not at the time it is being set instead of the way the redis_session_store sets and gets from redis when requested and so the updated value would be available to other requests immediately.  Also the redis_session_store only retrieves values in the session that you request specifically, the expression-session compatible version will retrieve all session values at the beginning of the request.  
+
 While the express-session store adapter is slightly less efficient than standard Sidecar usage, this can be an acceptable trade-off if you need session data to be portable between Node.js and CFML.
 
 **Loss of `onSessionEnd()` callback support**
@@ -61,6 +63,8 @@ Express-session typically relies on Redis TTL to expunge expired sessions; where
 **Loss of `_getAllSessions()` method**
 
 As a result of removing the session expiration index, there is now no way to get a list of all active session id's. While part of Sidecar's public API, at present this method is only used for testing Sidecar.
+
+Note: an alternative would be to use a different store with your express-session that matched sidecar semantics instead - doing so and researching the pros and cons of such a solution is currently left as an exercise for the reader.
 
 ## How to run the tests
 


### PR DESCRIPTION
Also adds some documentation about the different approach that this adapter takes to the readme. This PR does not break backwards compatibility, simply adds a different approach to storing the data which is compatible with express-session.

I intend to add core docs (in the empty section I added for them) for the standard Sidecar approach soon. Not sure yet if that means before or after this PR is merged. :)